### PR TITLE
Directory-related Bugfixes

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -40,6 +40,12 @@ steps:
 
     Boolean value, when set to true, builds artficat zip file.
 
+#### projectDir
+
+    *Optional*
+
+    Directory in workspace containing your godot project.
+
 #### debugMode
 
     *Optional*
@@ -50,11 +56,11 @@ steps:
 
 #### build
 
-    The location the outputed build is placed.
+    The location the outputed build is placed relative to GitHub Workspace.
 
 #### artifact
 
-    The location the outputed artifact is placed.
+    The location the outputed artifact is placed relative to GitHub Workspace.
 
 
 ## Credits

--- a/action.yml
+++ b/action.yml
@@ -10,12 +10,13 @@ inputs:
     required: true
   subdirectory:
     description: 'Optional name of the subdirectory to put exported project in'
-    required: false
+    default: ""
   package:
     description: 'Set true to output an artifact zip file'
-    required: false
+    default: false
   projectDir:
     description: 'Location of Godot project in repository'
+    default: ""
   debugMode:
     description: 'Whether or not to use `--export-debug`'
     default: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,7 +19,7 @@ fi
 echo "Building $1 for $2"
 mkdir -p ~/build/${SubDirectoryLocation:-""}
 cd ${5-"~"}
-godot --${mode} $2 ~/build/${SubDirectoryLocation:-""}$1
+godot -v --${mode} $2 ~/build/${SubDirectoryLocation:-""}$1
 cd ~
 
 echo ::set-output name=build::~/build/${SubDirectoryLocation:-""}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,23 +12,26 @@ fi
 mode="export"
 if [ "$6" = "true" ]
 then
+    echo "Exporting in debug mode!"
     mode="export-debug"
 fi
 
 # Export for project
 echo "Building $1 for $2"
-mkdir -p ~/build/${SubDirectoryLocation:-""}
-cd ${5-"~"}
-godot -v --${mode} $2 ~/build/${SubDirectoryLocation:-""}$1
-cd ~
+mkdir -p $GITHUB_WORKSPACE/build/${SubDirectoryLocation:-""}
+cd ${5-"$GITHUB_WORKSPACE"}
+godot --${mode} $2 $GITHUB_WORKSPACE/build/${SubDirectoryLocation:-""}$1
+echo "Build Done"
 
-echo ::set-output name=build::~/build/${SubDirectoryLocation:-""}
+echo ::set-output name=build::build/${SubDirectoryLocation:-""}
 
 
 if [ "$4" = "true" ]
 then
-    mkdir -p ~/package
-    cd ~/build
-    zip ~/package/artifact.zip ${SubDirectoryLocation:-"."} -r
-    echo ::set-output name=artifact::~/package/artifact.zip
+    echo "Packing Build"
+    mkdir -p $GITHUB_WORKSPACE/package
+    cd $GITHUB_WORKSPACE/build
+    zip $GITHUB_WORKSPACE/package/artifact.zip ${SubDirectoryLocation:-"."} -r
+    echo ::set-output name=artifact::package/artifact.zip
+    echo "Done"
 fi


### PR DESCRIPTION
- Build in GitHub workspace rather than home directory
- Changed export values to be relative to workspace

So outputs now have to be referenced as:
${{ github.workspace }}/${{ steps.build.outputs.build }}