### PR TITLE
Adjusted templates folder name

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-rt_#!/bin/sh
+#!/bin/sh
 set -e
 
 # Move godot templates already installed from the docker image to home

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,9 @@
-#!/bin/sh
+rt_#!/bin/sh
 set -e
 
 # Move godot templates already installed from the docker image to home
 mkdir -v -p ~/.local/share/godot/export_templates
-cp -a /root/.local/share/godot/templates/. ~/.local/share/godot/export_templates/
+cp -a /root/.local/share/godot/export_templates/. ~/.local/share/godot/export_templates/
 
 
 if [ "$3" != "" ]


### PR DESCRIPTION
A change has been made in the repo used as a base for the docker container ([godot-ci](https://github.com/abarichello/godot-ci))

In this [commit](https://github.com/abarichello/godot-ci/commit/66b7d6fef1760939f04c21a589cf1aa99855849d) the `templates` folder was renamed to `export_templates`. This change simply adjusts the path in the entry point.